### PR TITLE
Fix flake8 invocation in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ install:
   - pip install .
 
 script: 
-  - flake8 *.py tests --exclude=ez_setup.py --max-line-length=100
+  - flake8
   - nosetests --with-coverage --cover-package nested_dict
               --cover-inclusive --cover-min-percentage 85
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then make -C docs html; fi
-  - if [[ $TRAVIS_PYTHON_VERSION > 3.2 ]]; then make -C docs html; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then make -C docs html; fi

--- a/nested_dict/implementation.py
+++ b/nested_dict/implementation.py
@@ -35,6 +35,8 @@ from __future__ import division
 from collections import defaultdict
 
 import sys
+
+
 def flatten_nested_items(dictionary):
     """
     iterate through nested dictionary (with iterkeys() method)
@@ -91,8 +93,6 @@ class _recursive_dict(defaultdict):
     keys_flat = iterkeys_flat
     values_flat = itervalues_flat
 
-
-
     def to_dict(self, input_dict=None):
         """
         Converts the nested dictionary to a nested series of standard ``dict`` objects
@@ -130,12 +130,12 @@ def _nested_levels(level, nested_type):
     Helper function to create a specified degree of nested dictionaries
     """
     if level > 2:
-        return lambda: _recursive_dict(_nested_levels(level - 1,  nested_type))
+        return lambda: _recursive_dict(_nested_levels(level - 1, nested_type))
     if level == 2:
         if isinstance(nested_type, any_type):
             return lambda: _recursive_dict()
         else:
-            return lambda: _recursive_dict(_nested_levels(level - 1,  nested_type))
+            return lambda: _recursive_dict(_nested_levels(level - 1, nested_type))
     return nested_type
 
 
@@ -143,6 +143,7 @@ if sys.hexversion < 0x03000000:
     iteritems = dict.iteritems
 else:
     iteritems = dict.items
+
 
 # _________________________________________________________________________________________
 #
@@ -183,17 +184,20 @@ def _recursive_update(nd, other):
             nd[key] = value
     return nd
 
+
 # _________________________________________________________________________________________
 #
 #   nested_dict
 #
 # _________________________________________________________________________________________
 class nested_dict(_recursive_dict):
+
     def update(self, other):
         """
         Update recursively
         """
         _recursive_update(self, other)
+
     def __init__(self, *param, **named_param):
         """
         Takes one or two parameters

--- a/tests/test_nested_dict.py
+++ b/tests/test_nested_dict.py
@@ -31,12 +31,14 @@ class Test_nested_dict_default(unittest.TestCase):
         nd['new york']['queens county']['plumbers'] = 9
         nd['new york']['queens county']['salesmen'] = 36
 
-        expected_result = sorted([(('new jersey', 'mercer county', 'plumbers'),        3),
-                                  (('new jersey', 'mercer county', 'programmers'),    81),
-                                  (('new jersey', 'middlesex county', 'programmers'), 81),
-                                  (('new jersey', 'middlesex county', 'salesmen'),    62),
-                                  (('new york', 'queens county', 'plumbers'),          9),
-                                  (('new york', 'queens county', 'salesmen'),         36)])
+        expected_result = sorted([
+            (('new jersey', 'mercer county', 'plumbers'), 3),
+            (('new jersey', 'mercer county', 'programmers'), 81),
+            (('new jersey', 'middlesex county', 'programmers'), 81),
+            (('new jersey', 'middlesex county', 'salesmen'), 62),
+            (('new york', 'queens county', 'plumbers'), 9),
+            (('new york', 'queens county', 'salesmen'), 36),
+        ])
         all = sorted(tup for tup in nd.iteritems_flat())
         self.assertEqual(all, expected_result)
         all = sorted(tup for tup in nd.items_flat())
@@ -124,9 +126,9 @@ class Test_nested_dict_list(unittest.TestCase):
         nd['new jersey']['middlesex county'].append('staff')
         nd['new york']['queens county'].append('cricketers')
         all = sorted(tup for tup in nd.iteritems_flat())
-        self.assertEqual(all, [(('new jersey', 'mercer county'),    ['plumbers', 'programmers']),
+        self.assertEqual(all, [(('new jersey', 'mercer county'), ['plumbers', 'programmers']),
                                (('new jersey', 'middlesex county'), ['salesmen', 'staff']),
-                               (('new york', 'queens county'),      ['cricketers']),
+                               (('new york', 'queens county'), ['cricketers']),
                                ])
         all = sorted(tup for tup in nd.itervalues_flat())
         self.assertEqual(all, [['cricketers'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,4 @@
+[flake8]
+ignore=E265
+exclude=ez_setup.py,docs/source/conf.py,build/*
+max-line-length=100


### PR DESCRIPTION
flake8 was invoked with '*.py tests' which was only checking
setup.py and Python files in tests/, and not checking any of
the nested_dict modules.

Use tox.ini to specify the files to be excluded, which allows
flake8 to include all other Python files found.

Fix whitespace related errors.

Ignore code E265 due to several `#print..` lines.

Also simplify the invocation of the sphinx docs command in .travis.yml
