### PR TITLE
Add PyPy 3 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.4"
   - "3.5"
   - "pypy"
+  - "pypy3"
 
 install:
   - pip install -r requirements.txt
@@ -15,4 +16,4 @@ script:
   - flake8
   - nosetests --with-coverage --cover-package nested_dict
               --cover-inclusive --cover-min-percentage 85
-  - if [[ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then make -C docs html; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy3 ]]; then make -C docs html; fi


### PR DESCRIPTION
As Sphinx docs build fails on PyPy 3, skip that part of build script,
replacing previous skip of Sphinx docs build on Python 3.2,
which is no longer included in the build matrix.
