### PR TITLE
Update docstrings to PEP 257

### DIFF
--- a/nested_dict/__init__.py
+++ b/nested_dict/__init__.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-"""
-`nested_dict` provides dictionaries with multiple levels of nested-ness:
-"""
+"""`nested_dict` provides dictionaries with multiple levels of nested-ness."""
 __version__ = '1.61'
 from .implementation import nested_dict
 

--- a/nested_dict/implementation.py
+++ b/nested_dict/implementation.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
+"""`nested_dict` provides dictionaries with multiple levels of nested-ness."""
 from __future__ import print_function
 from __future__ import division
-"""
-`nested_dict` provides dictionaries with multiple levels of nested-ness:
-"""
 
 ################################################################################
 #
@@ -39,6 +37,8 @@ import sys
 
 def flatten_nested_items(dictionary):
     """
+    Flatten a nested_dict.
+
     iterate through nested dictionary (with iterkeys() method)
          and return with nested keys flattened into a tuple
     """
@@ -59,7 +59,9 @@ def flatten_nested_items(dictionary):
 
 class _recursive_dict(defaultdict):
     """
-    Parent class of nested_dict. Defined separately for _nested_levels to work
+    Parent class of nested_dict.
+
+    Defined separately for _nested_levels to work
     transparently, so dictionaries with a specified (and constant) degree of nestedness
     can be created easily.
 
@@ -67,25 +69,19 @@ class _recursive_dict(defaultdict):
         recursively.
 
     """
-    def iteritems_flat(self):
-        """
-        iterate through values with nested keys flattened into a tuple
-        """
 
+    def iteritems_flat(self):
+        """Iterate through items with nested keys flattened into a tuple."""
         for key, value in flatten_nested_items(self):
             yield key, value
 
     def iterkeys_flat(self):
-        """
-        iterate through values with nested keys flattened into a tuple
-        """
+        """Iterate through keys with nested keys flattened into a tuple."""
         for key, value in flatten_nested_items(self):
             yield key
 
     def itervalues_flat(self):
-        """
-        iterate through values with nested keys flattened into a tuple
-        """
+        """Iterate through values with nested keys flattened into a tuple."""
         for key, value in flatten_nested_items(self):
             yield value
 
@@ -94,9 +90,7 @@ class _recursive_dict(defaultdict):
     values_flat = itervalues_flat
 
     def to_dict(self, input_dict=None):
-        """
-        Converts the nested dictionary to a nested series of standard ``dict`` objects
-        """
+        """Convert the nested dictionary to a nested series of standard ``dict`` objects."""
         #
         # Calls itself recursively to unwind the dictionary.
         # Use to_dict() to start at the top level of nesting
@@ -114,25 +108,21 @@ class _recursive_dict(defaultdict):
         return plain_dict
 
     def __str__(self, indent=None):
-        """
-        string version of self
-        """
+        """Representation of self as a string."""
         import json
         return json.dumps(self.to_dict(), indent=indent)
 
 
-class any_type(object):
+class _any_type(object):
     pass
 
 
 def _nested_levels(level, nested_type):
-    """
-    Helper function to create a specified degree of nested dictionaries
-    """
+    """Helper function to create a specified degree of nested dictionaries."""
     if level > 2:
         return lambda: _recursive_dict(_nested_levels(level - 1, nested_type))
     if level == 2:
-        if isinstance(nested_type, any_type):
+        if isinstance(nested_type, _any_type):
             return lambda: _recursive_dict()
         else:
             return lambda: _recursive_dict(_nested_levels(level - 1, nested_type))
@@ -151,6 +141,7 @@ else:
 #
 # _________________________________________________________________________________________
 def nested_dict_from_dict(orig_dict, nd):
+    """Helper to build nested_dict from a dict."""
     for key, value in iteritems(orig_dict):
         if isinstance(value, (dict,)):
             nd[key] = nested_dict_from_dict(value, nested_dict())
@@ -191,15 +182,20 @@ def _recursive_update(nd, other):
 #
 # _________________________________________________________________________________________
 class nested_dict(_recursive_dict):
+    """
+    Nested dict.
+
+    Uses defaultdict to automatically add levels of nested dicts and other types.
+    """
 
     def update(self, other):
-        """
-        Update recursively
-        """
+        """Update recursively."""
         _recursive_update(self, other)
 
     def __init__(self, *param, **named_param):
         """
+        Constructor.
+
         Takes one or two parameters
             1) int, [TYPE]
             1) dict
@@ -212,7 +208,7 @@ class nested_dict(_recursive_dict):
         if len(param) == 1:
             # int = level
             if isinstance(param[0], int):
-                self.factory = _nested_levels(param[0], any_type())
+                self.factory = _nested_levels(param[0], _any_type())
                 defaultdict.__init__(self, self.factory)
                 return
             # existing dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 coverage
 flake8
+flake8-docstrings
 nose
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@
 # it under the terms of the MIT license as found here
 # http://opensource.org/licenses/MIT.
 #
+"""Setup module for nested-dict."""
 
 import re
 import os
@@ -26,7 +27,8 @@ except ImportError:
 # out of the module.
 def parse_version(module_file):
     """
-    Parses the version string from the specified file.
+    Parse the version string from the specified file.
+
     This implementation is ugly, but there doesn't seem to be a good way
     to do this in general at the moment.
     """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test modules for nested-dict."""

--- a/tests/test_nested_dict.py
+++ b/tests/test_nested_dict.py
@@ -1,8 +1,4 @@
-"""
-
-    test_nested_dict.py
-
-"""
+"""Test module for nested_dict."""
 from __future__ import print_function
 
 
@@ -16,12 +12,11 @@ parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, parent_dir)
 
 
-class Test_nested_dict_default(unittest.TestCase):
+class Test_nested_dict_constructor(unittest.TestCase):
+    """Test nested_dict constructor parameters."""
 
     def test_default(self):
-        """
-            test a range of nested_dict
-        """
+        """Test constructor without parameters."""
         from nested_dict import nested_dict
         nd = nested_dict()
         nd['new jersey']['mercer county']['plumbers'] = 3
@@ -44,23 +39,8 @@ class Test_nested_dict_default(unittest.TestCase):
         all = sorted(tup for tup in nd.items_flat())
         self.assertEqual(all, expected_result)
 
-import sys
-if sys.version < '3':
-    import codecs
-
-    def u(x):
-        return codecs.unicode_escape_decode(x)[0]
-else:
-
-    def u(x):
-        return x
-
-
-class Test_nested_dict_list(unittest.TestCase):
-
     def test_bad_init(self):
-        """
-        """
+        """Test with invalid constructor parameters."""
         #
         #   Maximum of four levels
         #
@@ -85,9 +65,7 @@ class Test_nested_dict_list(unittest.TestCase):
             pass
 
     def test_fixed_nesting(self):
-        """
-        Fixed levels of nesting, no type specified
-        """
+        """Fixed levels of nesting, no type specified."""
         #
         #   Maximum of four levels
         #
@@ -115,9 +93,7 @@ class Test_nested_dict_list(unittest.TestCase):
             pass
 
     def test_list(self):
-        """
-            test a range of nested_dict
-        """
+        """Test with nested type of `list`."""
         import nested_dict
         nd = nested_dict.nested_dict(2, list)
         nd['new jersey']['mercer county'].append('plumbers')
@@ -153,10 +129,12 @@ class Test_nested_dict_list(unittest.TestCase):
                                                                   "staff"]},
                               "new york": {"queens county": ["cricketers"]}})
 
+
+class Test_nested_dict_methods(unittest.TestCase):
+    """Test methods of nested_dict."""
+
     def test_iteritems_flat(self):
-        """
-        test iteritems_flat()
-        """
+        """Test iteritems_flat method."""
         import nested_dict
         a = nested_dict.nested_dict()
         a['1']['2']['3'] = 3
@@ -164,10 +142,7 @@ class Test_nested_dict_list(unittest.TestCase):
         self.assertEqual(sorted(a.iteritems_flat()), [(('1', '2', '3'), 3), (('A', 'B'), 15)])
 
     def test_iterkeys_flat(self):
-        """
-        test iterkeys_flat
-        iterate through values with nested keys flattened into a tuple
-        """
+        """Test iterkeys_flat method."""
         import nested_dict
         a = nested_dict.nested_dict()
         a['1']['2']['3'] = 3
@@ -175,10 +150,7 @@ class Test_nested_dict_list(unittest.TestCase):
         self.assertEqual(sorted(a.iterkeys_flat()), [('1', '2', '3'), ('A', 'B')])
 
     def test_itervalues_flat(self):
-        """
-        itervalues_flat
-        iterate through values as a single list, without considering the degree of nesting
-        """
+        """Test itervalues_flat method."""
         import nested_dict
         a = nested_dict.nested_dict()
         a['1']['2']['3'] = 3
@@ -186,10 +158,7 @@ class Test_nested_dict_list(unittest.TestCase):
         self.assertEqual(sorted(a.itervalues_flat()), [3, 15])
 
     def test_to_dict(self):
-        """
-        to_dict()
-        Converts the nested dictionary to a nested series of standard ``dict`` objects
-        """
+        """Test to_dict method."""
         import nested_dict
         a = nested_dict.nested_dict()
         a['1']['2']['3'] = 3
@@ -202,20 +171,16 @@ class Test_nested_dict_list(unittest.TestCase):
         self.assertEqual(b, {'1': {'2': {'3': 3}}, 'A': {'B': 15}})
 
     def test_str(self):
-        """
-        str()
-        """
+        """Test __str__ method."""
         import nested_dict
         import json
         a = nested_dict.nested_dict()
         a['1']['2']['3'] = 3
         a['A']['B'] = 15
-        self.assertEqual(json.loads(str(a)), {u('1'): {u('2'): {u('3'): 3}}, u('A'): {u('B'): 15}})
+        self.assertEqual(json.loads(str(a)), {'1': {'2': {'3': 3}}, 'A': {'B': 15}})
 
     def test_update(self):
-        """
-        update()
-        """
+        """Test update method."""
         import nested_dict
 
         #

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
-ignore=E265
+ignore=D203,E265
 exclude=ez_setup.py,docs/source/conf.py,build/*
 max-line-length=100


### PR DESCRIPTION
Disable D203 which implemented the old PEP 257 rule for
class docstrings, which was replaced by D211.
