### PR TITLE
Optional merge strategies

### DIFF
--- a/USAGE.TXT
+++ b/USAGE.TXT
@@ -29,21 +29,21 @@
 	nd4["human"]["chr1"]+=3
 	nd4["human"]["chr3"]+=4
 
-3) Dictionaries with lists or sets (or arbitrary objects) can have custom merge strategies:
+3) Dictionaries with lists or sets (or arbitrary objects) can have custom combine_policies:
 
 
 	> nd1 = nested_dict({'a':1,'f':[1,3]})
 	> nd2 = nested_dict({'a':1,'f':[1,2]})
 	
-	# use built-in strategy to merge lists
-	> nd1.update(nd2, strategies=['uniquely_extend_list'])
+	# use built-in combine_policy to merge lists
+	> nd1.update(nd2, combine_policies=['uniquely_extend_list'])
 	{'a':1,'f':[1,3,2]}
 	
-Here we are using the built-in strategy_options.  
-If your dict contains structures you may specify which ones update() will use with the strategies kwarg (list).
-You may also supply your own strategy_options kwarg (list)
+Here we are using the built-in combine_policy_options.  
+If your dict contains structures you may specify which ones update() will use with the combine_policies kwarg (list).
+You may also supply your own combine_policy_options kwarg (list)
 
-	default_strategy_options=[
+	default_combine_policy_options=[
 				  {'name': 'uniquely_extend_list', 'signature': (list,list), 
                    'combiner': lambda x,y: x + list(set(y) - set(x)) },
                   

--- a/USAGE.TXT
+++ b/USAGE.TXT
@@ -29,3 +29,28 @@
 	nd4["human"]["chr1"]+=3
 	nd4["human"]["chr3"]+=4
 
+3) Dictionaries with lists or sets (or arbitrary objects) can have custom merge strategies:
+
+
+	> nd1 = nested_dict({'a':1,'f':[1,3]})
+	> nd2 = nested_dict({'a':1,'f':[1,2]})
+	
+	# use built-in strategy to merge lists
+	> nd1.update(nd2, strategies=['uniquely_extend_list'])
+	{'a':1,'f':[1,3,2]}
+	
+Here we are using the built-in strategy_options.  
+If your dict contains structures you may specify which ones update() will use with the strategies kwarg (list).
+You may also supply your own strategy_options kwarg (list)
+
+	default_strategy_options=[
+				  {'name': 'uniquely_extend_list', 'signature': (list,list), 
+                   'combiner': lambda x,y: x + list(set(y) - set(x)) },
+                  
+                  {'name': 'list_of_union', 'signature': (list,list), 
+                   'combiner': lambda x,y: list(set(y) + set(x)) },
+                  
+                  {'name': 'symmetric_difference', 'signature': (set,set),
+                   'combiner': lambda x,y: x.symmetric_difference(y)},
+                   ]
+	

--- a/USAGE.TXT
+++ b/USAGE.TXT
@@ -53,4 +53,14 @@ You may also supply your own combine_policy_options kwarg (list)
                   {'name': 'symmetric_difference', 'signature': (set,set),
                    'combiner': lambda x,y: x.symmetric_difference(y)},
                    ]
-	
+
+Here is an example of creating your own useful combiner
+
+	    > combine_policy_options=[
+                  {'name': 'rabbits', 'signature': (list,list), 
+                   'combiner': lambda x,y: 'look rabbits' }]
+        > nd1 = nested_dict.nested_dict({'a':1,'f':[1,3,3]})
+        > nd2 = nested_dict.nested_dict({'a':1,'f':[1,2]})
+        > nd1.update(nd2,
+                   combine_policies=['rabbits'],                               combine_plicy_options=combine_policy_options)
+        {'a':1,'f':'look rabbits'})

--- a/nested_dict/implementation.py
+++ b/nested_dict/implementation.py
@@ -169,7 +169,7 @@ def _recursive_update(nd, other, strategies=[]):
     for key, value in iteritems(other):
         #print ("key=", key)
         strategy = get_strategy(nd[key], other[key], strategies, strategy_options)
-        print("strategy for {} {} is {}".format(key, value, strategy))
+        #print("strategy for {} {} is {}".format(key, value, strategy))
         if isinstance(value, (dict,)):
 
             # recursive update if my item is nested_dict
@@ -187,7 +187,7 @@ def _recursive_update(nd, other, strategies=[]):
                 nd[key] = value
         # combine by specified matching strategy
         elif strategy:
-            print(nd[key], strategy(nd[key], value))
+            #print(nd[key], strategy(nd[key], value))
             nd[key] = strategy(nd[key], value)        
         # other not dict: overwrite
         else:

--- a/nested_dict/implementation.py
+++ b/nested_dict/implementation.py
@@ -151,9 +151,9 @@ def nested_dict_from_dict(orig_dict, nd):
 
 default_combine_policy_options=[
                   {'name': 'uniquely_extend_list', 'signature': (list,list), 
-                   'combiner': lambda x,y: x + list(set(y) - set(x)) },
-                  {'name': 'list_of_union', 'signature': (list,list), 
-                   'combiner': lambda x,y: list(set(y) + set(x)) },
+                   'combiner': lambda x,y: x + [yy for yy in y if yy not in x] },
+                  {'name': 'sorted_list_of_union', 'signature': (list,list), 
+                   'combiner': lambda x,y: sorted(list(set(y).union(set(x)))) },
                   {'name': 'symmetric_difference', 'signature': (set,set),
                    'combiner': lambda x,y: x.symmetric_difference(y)},
                    ]

--- a/nested_dict/implementation.py
+++ b/nested_dict/implementation.py
@@ -149,7 +149,7 @@ def nested_dict_from_dict(orig_dict, nd):
             nd[key] = value
     return nd
 
-strategy_options=[{'name': 'uniquely_extend_list', 'signature': (list,list), 
+combine_policy_options=[{'name': 'uniquely_extend_list', 'signature': (list,list), 
                    'combiner': lambda x,y: x + list(set(y) - set(x)) },
                   {'name': 'list_of_union', 'signature': (list,list), 
                    'combiner': lambda x,y: list(set(y) + set(x)) },
@@ -158,8 +158,8 @@ strategy_options=[{'name': 'uniquely_extend_list', 'signature': (list,list),
                    ]
 
 
-def get_strategy(val1, val2, strategies, strategy_options):
-    for option in strategy_options: 
+def get_combine_policy(val1, val2, strategies, combine_policy_options):
+    for option in combine_policy_options: 
         if ((type(val1),type(val2)) == option['signature']) and (option['name'] in strategies):
             return option['combiner']
     else:
@@ -168,8 +168,8 @@ def get_strategy(val1, val2, strategies, strategy_options):
 def _recursive_update(nd, other, strategies=[]):
     for key, value in iteritems(other):
         #print ("key=", key)
-        strategy = get_strategy(nd[key], other[key], strategies, strategy_options)
-        #print("strategy for {} {} is {}".format(key, value, strategy))
+        combine_policy = get_combine_policy(nd[key], other[key], strategies, combine_policy_options)
+        #print("combine_policy for {} {} is {}".format(key, value, combine_policy))
         if isinstance(value, (dict,)):
 
             # recursive update if my item is nested_dict
@@ -185,10 +185,10 @@ def _recursive_update(nd, other, strategies=[]):
             else:
                 #print ("self not nested dict or dict: overwrite", key)
                 nd[key] = value
-        # combine by specified matching strategy
-        elif strategy:
-            #print(nd[key], strategy(nd[key], value))
-            nd[key] = strategy(nd[key], value)        
+        # combine by specified matching combine_policy
+        elif combine_policy:
+            #print(nd[key], combine_policy(nd[key], value))
+            nd[key] = combine_policy(nd[key], value)        
         # other not dict: overwrite
         else:
             #print ("other not dict: overwrite", key)

--- a/tests/test_nested_dict.py
+++ b/tests/test_nested_dict.py
@@ -263,3 +263,14 @@ class Test_nested_dict_methods(unittest.TestCase):
         nd2 = nested_dict.nested_dict({'a':1,'f':[1,2]})
         nd1.update(nd2, combine_policies=['list_of_union'])
         self.assertEqual(nd1.to_dict, {'a':1,'f':[1,3,2]})
+
+        #
+        # custom_combine_policy
+        #
+        combine_policy_options=[
+                  {'name': 'rabbits', 'signature': (list,list), 
+                   'combiner': lambda x,y: 'look rabbits' },
+        nd1 = nested_dict.nested_dict({'a':1,'f':[1,3,3]})
+        nd2 = nested_dict.nested_dict({'a':1,'f':[1,2]})
+        nd1.update(nd2, combine_policies=['rabbits'], combine_plicy_options=combine_policy_options)
+        self.assertEqual(nd1.to_dict, {'a':1,'f':'look rabbits'})

--- a/tests/test_nested_dict.py
+++ b/tests/test_nested_dict.py
@@ -254,23 +254,24 @@ class Test_nested_dict_methods(unittest.TestCase):
         nd1 = nested_dict.nested_dict({'a':1,'f':[1,3,3]})
         nd2 = nested_dict.nested_dict({'a':1,'f':[1,2]})
         nd1.update(nd2, combine_policies=['uniquely_extend_list'])
-        self.assertEqual(nd1.to_dict, {'a':1,'f':[1,3,3,2]})
+        self.assertEqual(nd1.to_dict(), {'a':1,'f':[1,3,3,2]})
 
         #
         # list_of_union
         #
         nd1 = nested_dict.nested_dict({'a':1,'f':[1,3,3]})
         nd2 = nested_dict.nested_dict({'a':1,'f':[1,2]})
-        nd1.update(nd2, combine_policies=['list_of_union'])
-        self.assertEqual(nd1.to_dict, {'a':1,'f':[1,3,2]})
+        nd1.update(nd2, combine_policies=['sorted_list_of_union'])
+        self.assertEqual(nd1.to_dict(), {'a':1,'f':[1,2,3]})
 
         #
         # custom_combine_policy
         #
         combine_policy_options=[
                   {'name': 'rabbits', 'signature': (list,list), 
-                   'combiner': lambda x,y: 'look rabbits' },
+                   'combiner': lambda x,y: 'look rabbits' }
+                ]
         nd1 = nested_dict.nested_dict({'a':1,'f':[1,3,3]})
         nd2 = nested_dict.nested_dict({'a':1,'f':[1,2]})
-        nd1.update(nd2, combine_policies=['rabbits'], combine_plicy_options=combine_policy_options)
-        self.assertEqual(nd1.to_dict, {'a':1,'f':'look rabbits'})
+        nd1.update(nd2, combine_policies=['rabbits'], combine_policy_options=combine_policy_options)
+        self.assertEqual(nd1.to_dict(), {'a':1,'f':'look rabbits'})

--- a/tests/test_nested_dict.py
+++ b/tests/test_nested_dict.py
@@ -243,3 +243,23 @@ class Test_nested_dict_methods(unittest.TestCase):
         # d1[2][3][4][5] = 6 but d1[2][3][5] should still be a default dict of list
         d1[2][3][5].append(4)
         self.assertEqual(d1.to_dict(), {1: {2: {3: [4], 4: [4]}}, 2: {3: {4: {5: 6}, 5: [4]}}})
+
+    def test_update_with_strategies(self):
+        """Test update with strategies"""
+        import nested_dict
+
+        #
+        # uniquely_extend_list
+        #
+        nd1 = nested_dict.nested_dict({'a':1,'f':[1,3,3]})
+        nd2 = nested_dict.nested_dict({'a':1,'f':[1,2]})
+        nd1.update(nd2, strategies=['uniquely_extend_list'])
+        self.assertEqual(nd1.to_dict, {'a':1,'f':[1,3,3,2]})
+
+        #
+        # list_of_union
+        #
+        nd1 = nested_dict.nested_dict({'a':1,'f':[1,3,3]})
+        nd2 = nested_dict.nested_dict({'a':1,'f':[1,2]})
+        nd1.update(nd2, strategies=['list_of_union'])
+        self.assertEqual(nd1.to_dict, {'a':1,'f':[1,3,2]})

--- a/tests/test_nested_dict.py
+++ b/tests/test_nested_dict.py
@@ -244,8 +244,8 @@ class Test_nested_dict_methods(unittest.TestCase):
         d1[2][3][5].append(4)
         self.assertEqual(d1.to_dict(), {1: {2: {3: [4], 4: [4]}}, 2: {3: {4: {5: 6}, 5: [4]}}})
 
-    def test_update_with_strategies(self):
-        """Test update with strategies"""
+    def test_update_with_combine_policies(self):
+        """Test update with combine_policies"""
         import nested_dict
 
         #
@@ -253,7 +253,7 @@ class Test_nested_dict_methods(unittest.TestCase):
         #
         nd1 = nested_dict.nested_dict({'a':1,'f':[1,3,3]})
         nd2 = nested_dict.nested_dict({'a':1,'f':[1,2]})
-        nd1.update(nd2, strategies=['uniquely_extend_list'])
+        nd1.update(nd2, combine_policies=['uniquely_extend_list'])
         self.assertEqual(nd1.to_dict, {'a':1,'f':[1,3,3,2]})
 
         #
@@ -261,5 +261,5 @@ class Test_nested_dict_methods(unittest.TestCase):
         #
         nd1 = nested_dict.nested_dict({'a':1,'f':[1,3,3]})
         nd2 = nested_dict.nested_dict({'a':1,'f':[1,2]})
-        nd1.update(nd2, strategies=['list_of_union'])
+        nd1.update(nd2, combine_policies=['list_of_union'])
         self.assertEqual(nd1.to_dict, {'a':1,'f':[1,3,2]})


### PR DESCRIPTION
Add the ability to specify how merges are made on lists, sets or other objects.

Fixes  optional merge strategies for lists/sets #10 
